### PR TITLE
Button 컴포넌트 수정 (with review)

### DIFF
--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -56,5 +56,6 @@ module.exports = {
     'no-prototype-builtins': 'off',
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
+    'react/jsx-props-no-spreading': 'off',
   }
 };

--- a/packages/ui/src/button/index.tsx
+++ b/packages/ui/src/button/index.tsx
@@ -10,31 +10,21 @@ type ButtonVariant = "disabled" | "active";
 interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
   variant: ButtonVariant;
   children: ReactNode;
-  handleClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export default function Button({
-  variant,
+  variant = "active",
   children,
-  className,
-  handleClick,
   ...props
 }: ButtonProps) {
-  // TODO: 추후 클릭이벤트에 따른 로직 처리
-  const clickHandler = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    handleClick(e);
-  };
-
   return (
     <button
-      className={
-        variant === "disabled"
-          ? clsx(styles.disabled, className)
-          : clsx(styles.base, className)
-      }
+      className={clsx(
+        styles.base,
+        variant === "disabled" && styles.disabled,
+        props.className,
+      )}
       type="button"
-      onClick={(e) => clickHandler(e)}
       disabled={variant === "disabled"}
       {...props}
     >


### PR DESCRIPTION
### What is this PR?
- Button 컴포넌트 리뷰 반영
---
### What has changed?
- 경로: `ui > src > button`
- `props spreading`관련된 lint설정으로 인해 `warn`경고가 떠, 해당 rule을 `off`해두었습니다.
---
### A notice to reviewers...
- - 리뷰에 따른 수정만 해주었습니다. 리뷰는 디스코드에서 이뤄져, 깃허브에서는 리뷰가 따로 달려있진 않습니다.
