### PR TITLE
fix: url 오타 수정 & credentials 설정 위치 수정

### DIFF
--- a/apps/swifty-bank/app/_api/auth.ts
+++ b/apps/swifty-bank/app/_api/auth.ts
@@ -1,16 +1,11 @@
-import exp from "constants";
-import { CheckInfo } from "./type";
-import URL from "./url";
-import { postWithToken, postWithoutToken } from "./utils";
+import { CheckInfo } from "@/_api/type";
+import URL from "@/_api/url";
+import { post } from "@/_api/utils";
 
 // Authentication API
-const signwithForm = async (
-  temporaryToken: string,
-  pushedOrder: Number[],
-  deviceId: string,
-) => {
+const signwithForm = async (pushedOrder: Number[], deviceId: string) => {
   try {
-    const res = await postWithToken<{
+    const res = await post<{
       tokens: string;
       success: true;
       availablePassword: true;
@@ -20,7 +15,7 @@ const signwithForm = async (
         pushedOrder,
         deviceId,
       },
-      temporaryToken,
+      true,
     );
 
     return res;
@@ -29,11 +24,11 @@ const signwithForm = async (
   }
 };
 
-const signOut = async (accessToken: string) => {
+const signOut = async () => {
   try {
-    const res = await postWithToken<{
+    const res = await post<{
       wasSignedOut: true;
-    }>(URL.AUTH.signout, {}, accessToken);
+    }>(URL.AUTH.signout, {}, true);
 
     return res;
   } catch (error) {
@@ -41,12 +36,12 @@ const signOut = async (accessToken: string) => {
   }
 };
 
-const reissueToken = async (refreshToken: string) => {
+const reissueToken = async () => {
   try {
-    const res = await postWithToken<{
+    const res = await post<{
       isSuccess: true;
       tokens: string;
-    }>(URL.AUTH.reissue, {}, refreshToken);
+    }>(URL.AUTH.reissue, {}, true);
 
     return res;
   } catch (error) {
@@ -54,11 +49,11 @@ const reissueToken = async (refreshToken: string) => {
   }
 };
 
-const logout = async (accessToken: string) => {
+const logout = async () => {
   try {
-    const res = await postWithToken<{
+    const res = await post<{
       isSuccessful: true;
-    }>(URL.AUTH.logout, {}, accessToken);
+    }>(URL.AUTH.logout, {}, true);
     return res;
   } catch (error) {
     throw new Error("로그아웃에 실패했습니다.");
@@ -67,10 +62,10 @@ const logout = async (accessToken: string) => {
 
 const checkLoginAvailable = async (data: CheckInfo) => {
   try {
-    const res = await postWithoutToken<{
+    const res = await post<{
       isAvailable: true;
       temporaryToken: string;
-    }>(URL.AUTH.checkLoginAvailable, { ...data });
+    }>(URL.AUTH.checkLoginAvailable, { ...data }, false);
 
     return res;
   } catch (error) {

--- a/apps/swifty-bank/app/_api/keypad.ts
+++ b/apps/swifty-bank/app/_api/keypad.ts
@@ -1,12 +1,12 @@
-import URL from "./url";
-import { getWithToken } from "./utils";
+import URL from "@/_api/url";
+import { get } from "@/_api/utils";
 
 // 보안 키패드 관련 API
 const getKeypad = async (temporaryToken: string) => {
   try {
-    const res = await getWithToken<{
+    const res = await get<{
       keypad: string;
-    }>(URL.KEYPAD.getKeypad, temporaryToken, {}, "no-cache");
+    }>(URL.KEYPAD.getKeypad, true, {}, "no-cache");
 
     return res;
   } catch (error) {

--- a/apps/swifty-bank/app/_api/sms.ts
+++ b/apps/swifty-bank/app/_api/sms.ts
@@ -1,17 +1,17 @@
-import URL from "./url";
-import { postWithToken } from "./utils";
+import URL from "@/_api/url";
+import { post } from "@/_api/utils";
 
 interface SMSResponse {
   isSuccess: true;
 }
 
 // SMS 인증 API
-const sendSMSCode = async (phoneNumber: string, temporaryToken: string) => {
+const sendSMSCode = async (phoneNumber: string) => {
   try {
-    const res = await postWithToken<SMSResponse>(
+    const res = await post<SMSResponse>(
       URL.SMS.sendCode,
       { phoneNumber },
-      temporaryToken,
+      true,
     );
 
     return res;
@@ -22,19 +22,15 @@ const sendSMSCode = async (phoneNumber: string, temporaryToken: string) => {
   }
 };
 
-const checkSMSCode = async (
-  temporaryToken: string,
-  phoneNumber: string,
-  verficationCode: string,
-) => {
+const checkSMSCode = async (phoneNumber: string, verficationCode: string) => {
   try {
-    const res = await postWithToken<SMSResponse>(
+    const res = await post<SMSResponse>(
       URL.SMS.checkCode,
       {
         phoneNumber,
         verficationCode,
       },
-      temporaryToken,
+      true,
     );
 
     return res;

--- a/apps/swifty-bank/app/_api/type.ts
+++ b/apps/swifty-bank/app/_api/type.ts
@@ -11,7 +11,7 @@ export interface CheckInfo extends Pick<User, "name" | "phoneNumber"> {
   mobileCarrier: MobileCarrier;
 }
 
-type MobileCarrier =
+export type MobileCarrier =
   | "SKT"
   | "KT"
   | "LGU+"

--- a/apps/swifty-bank/app/_api/url.ts
+++ b/apps/swifty-bank/app/_api/url.ts
@@ -16,7 +16,7 @@ const AUTH = {
   signout: `${baseURL}/auth/sign-out`,
   reissue: `${baseURL}/auth/reissue`,
   logout: `${baseURL}/auth/log-out`,
-  checkLoginAvailable: `${baseURL}/auth/check-login-availabilty`,
+  checkLoginAvailable: `${baseURL}/auth/check-login-availability`,
 };
 
 const KEYPAD = {

--- a/apps/swifty-bank/app/_api/user.ts
+++ b/apps/swifty-bank/app/_api/user.ts
@@ -1,19 +1,15 @@
-import { User } from "./type";
-import URL from "./url";
-import { getWithToken, patchWithToken, postWithToken } from "./utils";
+import { User } from "@/_api/type";
+import URL from "@/_api/url";
+import { get, patch, post } from "@/_api/utils";
 
 interface Response {
   message: string;
 }
 
 // 회원 API
-const checkPassword = async (accessToken: string, password: string) => {
+const checkPassword = async (password: string) => {
   try {
-    const res = await postWithToken<Response>(
-      URL.USER.password,
-      { password },
-      accessToken,
-    );
+    const res = await post<Response>(URL.USER.password, { password }, true);
 
     return res;
   } catch (error) {
@@ -21,13 +17,9 @@ const checkPassword = async (accessToken: string, password: string) => {
   }
 };
 
-const changePassword = async (accessToken: string, password: string) => {
+const changePassword = async (password: string) => {
   try {
-    const res = await patchWithToken<Response>(
-      URL.USER.password,
-      { password },
-      accessToken,
-    );
+    const res = await patch<Response>(URL.USER.password, { password }, true);
 
     return res;
   } catch (error) {
@@ -35,9 +27,9 @@ const changePassword = async (accessToken: string, password: string) => {
   }
 };
 
-const getUser = async (accessToken: string) => {
+const getUser = async () => {
   try {
-    const res = await getWithToken<User>(URL.USER.info, accessToken);
+    const res = await get<User>(URL.USER.info, true);
 
     return res;
   } catch (error) {
@@ -45,13 +37,9 @@ const getUser = async (accessToken: string) => {
   }
 };
 
-const updateUser = async (accessToken: string, data: User) => {
+const updateUser = async (data: User) => {
   try {
-    const res = await patchWithToken<Response>(
-      URL.USER.info,
-      { data },
-      accessToken,
-    );
+    const res = await patch<Response>(URL.USER.info, { data }, true);
 
     return res;
   } catch (error) {

--- a/apps/swifty-bank/app/_api/utils.ts
+++ b/apps/swifty-bank/app/_api/utils.ts
@@ -12,9 +12,9 @@ async function getWithToken<R>(
   try {
     const res = await fetch(url, {
       method: "GET",
+      credentials: "include",
       headers: {
         Authorization: `Bearer ${token}`,
-        credentials: "include",
         ...commonHeaders,
         ...headerOptions,
       },
@@ -41,9 +41,9 @@ async function postWithToken<R>(
   try {
     const res = await fetch(url, {
       method: "POST",
+      credentials: "include",
       headers: {
         Authorization: `Bearer ${token}`,
-        credentials: "include",
         ...commonHeaders,
         ...headerOptions,
       },
@@ -96,9 +96,9 @@ async function patchWithToken<R>(
   try {
     const res = await fetch(url, {
       method: "PATCH",
+      credentials: "include",
       headers: {
         Authorization: `Bearer ${token}`,
-        credentials: "include",
         ...commonHeaders,
         ...headerOptions,
       },

--- a/apps/swifty-bank/app/_api/utils.ts
+++ b/apps/swifty-bank/app/_api/utils.ts
@@ -1,3 +1,5 @@
+import { cookies } from "next/headers";
+
 const commonHeaders = {
   "Content-Type": "application/json",
 };
@@ -12,7 +14,7 @@ async function get<R>(
   try {
     const res = await fetch(url, {
       method: "GET",
-      ...(withCredentials && { credentials: "include" }),
+      ...(withCredentials && { Cookie: cookies().toString() }),
       headers: {
         ...commonHeaders,
         ...headerOptions,
@@ -40,7 +42,7 @@ async function post<R>(
   try {
     const res = await fetch(url, {
       method: "POST",
-      ...(withCredentials && { credentials: "include" }),
+      ...(withCredentials && { Cookie: cookies().toString() }),
       headers: {
         ...commonHeaders,
         ...headerOptions,
@@ -68,7 +70,7 @@ async function patch<R>(
   try {
     const res = await fetch(url, {
       method: "PATCH",
-      ...(withCredentials && { credentials: "include" }),
+      ...(withCredentials && { Cookie: cookies().toString() }),
       headers: {
         ...commonHeaders,
         ...headerOptions,

--- a/apps/swifty-bank/app/_api/utils.ts
+++ b/apps/swifty-bank/app/_api/utils.ts
@@ -2,19 +2,18 @@ const commonHeaders = {
   "Content-Type": "application/json",
 };
 
-async function getWithToken<R>(
+async function get<R>(
   url: string,
-  token: string,
+  withCredentials: boolean = true,
   headerOptions: Record<string, unknown> = {},
-  cache: RequestCache = "no-store",
+  cache: RequestCache = "force-cache",
   errorMessage: string = "",
 ): Promise<R> {
   try {
     const res = await fetch(url, {
       method: "GET",
-      credentials: "include",
+      ...(withCredentials && { credentials: "include" }),
       headers: {
-        Authorization: `Bearer ${token}`,
         ...commonHeaders,
         ...headerOptions,
       },
@@ -31,44 +30,17 @@ async function getWithToken<R>(
   }
 }
 
-async function postWithToken<R>(
+async function post<R>(
   url: string,
   data: Record<string, unknown>,
-  token: string,
+  withCredentials: boolean = true,
   headerOptions: Record<string, unknown> = {},
   errorMessage: string = "",
 ): Promise<R> {
   try {
     const res = await fetch(url, {
       method: "POST",
-      credentials: "include",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        ...commonHeaders,
-        ...headerOptions,
-      },
-      body: JSON.stringify(data),
-    });
-
-    if (!res.ok) {
-      throw new Error((await res.json()).message);
-    }
-
-    return res.json();
-  } catch (error) {
-    throw new Error(errorMessage);
-  }
-}
-
-async function postWithoutToken<R>(
-  url: string,
-  data: Record<string, unknown>,
-  headerOptions: Record<string, unknown> = {},
-  errorMessage: string = "",
-): Promise<R> {
-  try {
-    const res = await fetch(url, {
-      method: "POST",
+      ...(withCredentials && { credentials: "include" }),
       headers: {
         ...commonHeaders,
         ...headerOptions,
@@ -86,19 +58,18 @@ async function postWithoutToken<R>(
   }
 }
 
-async function patchWithToken<R>(
+async function patch<R>(
   url: string,
   data: Record<string, unknown>,
-  token: string,
+  withCredentials: boolean = true,
   headerOptions: Record<string, unknown> = {},
   errorMessage: string = "",
 ): Promise<R> {
   try {
     const res = await fetch(url, {
       method: "PATCH",
-      credentials: "include",
+      ...(withCredentials && { credentials: "include" }),
       headers: {
-        Authorization: `Bearer ${token}`,
         ...commonHeaders,
         ...headerOptions,
       },
@@ -115,4 +86,4 @@ async function patchWithToken<R>(
   }
 }
 
-export { getWithToken, postWithToken, postWithoutToken, patchWithToken };
+export { get, post, patch };


### PR DESCRIPTION
### What is this PR?
- 어제 merge한 API 인터페이스 관련 급한 수정사항이 있어 fix하여 PR올립니다. 
- 쿠키 사용에 따라 서버 호출 인터페이스를 수정하였습니다. 
- next.js fetch의 기본 cache 옵션에 맞게 get 함수의 cache 파라미터의 기본값을 'force-cache'로 변경하였습니다.
---
### What has changed?
- url 오타 수정 : /auth/check-login-availability
- credentials: "include" 설정 삭제 후, 쿠키 설정
- getWithToken, postWithToken, patchWithToken을 get, post, patch로 변경
- 인자로 withCredential 항목 추가하여 cookie 조회가 필요한 경우 true값을 전달하도록 함
- post 단일 인터페이스로 통합하면서 postWithoutToken 함수 삭제
---
### A notice to reviewers...
- 
---
### Screen

