### PR TITLE
fix : toast 관리 context로 교체

### DIFF
--- a/apps/swifty-bank/app/_component/Provider.tsx
+++ b/apps/swifty-bank/app/_component/Provider.tsx
@@ -1,10 +1,12 @@
-import { NextThemeProvider } from "@swifty/ui";
+import { NextThemeProvider, ToastProvider } from "@swifty/ui";
 import QueryProvider from "./QueryProvider";
 
 export default function Provider({ children }: { children: React.ReactNode }) {
   return (
     <NextThemeProvider>
-      <QueryProvider>{children}</QueryProvider>
+      <QueryProvider>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryProvider>
     </NextThemeProvider>
   );
 }

--- a/apps/swifty-bank/app/page.tsx
+++ b/apps/swifty-bank/app/page.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { container } from "./page.css";
-import { BottomSheet, Toast } from "@swifty/ui";
+import { BottomSheet, ToastContext } from "@swifty/ui";
 import { useBottomSheet } from "@swifty/hooks";
+import { useContext } from "react";
 
 export default function Page() {
   const { isOpen, open, close } = useBottomSheet();
+  const { showToast } = useContext(ToastContext);
+  const onClick = () => {
+    showToast({ content: "text", timer: 1 });
+  };
 
   return (
     <main className={container}>
@@ -18,7 +23,7 @@ export default function Page() {
       >
         asd
       </BottomSheet>
-      <Toast time={5}>새로운 계정이 생성되었습니다</Toast>
+      <button onClick={onClick}>Toast</button>
     </main>
   );
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,4 +6,4 @@ export { default as Heading } from "./heading";
 export { default as Input } from "./input";
 export { default as Select } from "./select";
 export { default as NextThemeProvider } from "./styles/ThemeProvider";
-export { default as Toast } from "./toast";
+export { ToastContext, default as ToastProvider } from "./toast";

--- a/packages/ui/src/toast/Toast.tsx
+++ b/packages/ui/src/toast/Toast.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import clsx from "clsx";
+import { HTMLMotionProps, motion } from "framer-motion";
+
+import { toastVariants } from "./motion";
+import styles from "./toast.css";
+
+export type ToastType = "success" | "error";
+export type ToastValue = {
+  children: string | JSX.Element;
+  type?: ToastType;
+};
+
+type Prop = ToastValue & HTMLMotionProps<"div">;
+
+export default function Toast({
+  type = "success",
+  className,
+  children,
+  ...props
+}: Prop) {
+  return (
+    <motion.div className={styles.container}>
+      <motion.div
+        className={clsx(
+          type === "error" && styles.errorToast,
+          type === "success" && styles.successToast,
+          className,
+        )}
+        variants={toastVariants}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        {...props}
+      >
+        {children}
+      </motion.div>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
### What is this PR?
-  toast 관리를 선언적으로 하기 위해 context API를 도입했습니다. 
- 이제 toast 호출이 필요한 경우 다음과 같이 함수를 호출해서 사용하면 됩니다. 
```tsx
"use client";

import { container } from "./page.css";
import { ToastContext } from "@swifty/ui";
import { useContext } from "react";

export default function Page() {
  const { showToast } = useContext(ToastContext);
  const onClick = () => {
    showToast({ content: "text", timer: 1 });
  };

  return (
    <main className={container}>
      <button onClick={onClick}>Toast</button>
    </main>
  );
}
```
---
### What has changed?
- 
---
### A notice to reviewers...
- 
---
### Screen

